### PR TITLE
Run on macOS 10.15

### DIFF
--- a/mac/keyrace-mac.xcodeproj/project.pbxproj
+++ b/mac/keyrace-mac.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		24AF66DA25DE66C500C6DB2C /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4137816025A19C3B004AD04D /* Info.plist */; };
 		4137815825A19C3A004AD04D /* keyrace_macApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4137815725A19C3A004AD04D /* keyrace_macApp.swift */; };
 		4137815C25A19C3B004AD04D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4137815B25A19C3B004AD04D /* Assets.xcassets */; };
 		4137815F25A19C3B004AD04D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4137815E25A19C3B004AD04D /* Preview Assets.xcassets */; };
@@ -154,6 +155,7 @@
 			files = (
 				4137815F25A19C3B004AD04D /* Preview Assets.xcassets in Resources */,
 				4137815C25A19C3B004AD04D /* Assets.xcassets in Resources */,
+				24AF66DA25DE66C500C6DB2C /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -347,7 +349,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nat.keyrace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -370,7 +372,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nat.keyrace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/mac/keyrace-mac.xcworkspace/contents.xcworkspacedata
+++ b/mac/keyrace-mac.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:keyrace-mac.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/mac/keyrace-mac.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/mac/keyrace-mac.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/mac/keyrace-mac/Info.plist
+++ b/mac/keyrace-mac/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrincipalClass</key>
+	<string>keyrace_mac.NatApplication</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/mac/keyrace-mac/keyrace_macApp.swift
+++ b/mac/keyrace-mac/keyrace_macApp.swift
@@ -15,16 +15,16 @@ import Foundation
 import Accessibility
 import Cocoa
 
-@available(OSX 11.0, *)
-@main
-struct MenuBarPopoverApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    var body: some Scene {
-        Settings{
-            EmptyView()
-        }
-    }
-}
+//@available(OSX 11.0, *)
+//@main
+//struct MenuBarPopoverApp: App {
+//    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+//    var body: some Scene {
+//        Settings{
+//            EmptyView()
+//        }
+//    }
+//}
 
 func formatCount(count: Int) -> String {
     var str = ""
@@ -376,6 +376,7 @@ class KeyTap {
     }
 }
 
+@NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusBarItem: NSStatusItem!
     var menubarItem: MenubarItem?
@@ -396,4 +397,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
+}
+
+class NatApplication: NSApplication {
+
+    let strongDelegate = AppDelegate()
+
+    override init() {
+        super.init()
+        self.delegate = strongDelegate
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
 }

--- a/mac/keyrace-mac/keyrace_macApp.swift
+++ b/mac/keyrace-mac/keyrace_macApp.swift
@@ -15,17 +15,6 @@ import Foundation
 import Accessibility
 import Cocoa
 
-//@available(OSX 11.0, *)
-//@main
-//struct MenuBarPopoverApp: App {
-//    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-//    var body: some Scene {
-//        Settings{
-//            EmptyView()
-//        }
-//    }
-//}
-
 func formatCount(count: Int) -> String {
     var str = ""
 


### PR DESCRIPTION
This PR lowers the deployment target to macOS 10.15 (Catalina) my mac, should still work for macOS 11 (but I cannot test this).

**Note:**
It crashes on line `keytrace_macApp.swift:104`:
```
keys[Int(keyCode)] += 1 // Index out of range
```
