### PR TITLE
Timebug

### DIFF
--- a/mac/keyrace-mac/MenubarItem.swift
+++ b/mac/keyrace-mac/MenubarItem.swift
@@ -41,6 +41,9 @@ public class HourAxisValueFormatter: NSObject, IAxisValueFormatter {
         if (value == 12.0) {
             return "noon"
         }
+        if (value == 0.0) {
+            return "12am"
+        }
 
         var str = "\(Int(value)%12)"
         

--- a/mac/keyrace-mac/keyrace_macApp.swift
+++ b/mac/keyrace-mac/keyrace_macApp.swift
@@ -142,7 +142,7 @@ class KeyTap {
         
         var mins : [Int] = []
         for i in (0...20).reversed() {
-            currMin - i > 0 ? mins.append(minutes[currMin - i]): mins.append(minutes[1440 - i])
+            currMin - i > 0 ? mins.append(minutes[currMin - i]): mins.append(minutes[1440 + i - (20 - currMin)])
         }
         return mins
     }

--- a/mac/keyrace-mac/keyrace_macApp.swift
+++ b/mac/keyrace-mac/keyrace_macApp.swift
@@ -102,18 +102,18 @@ class KeyTap {
         if (lastDay != day) {
             lastDay = day
             keycount = 0
-            minutes.replaceSubrange(0..<1420, with: repeatElement(0, count: 1420)) // Leave last 20 minutes of yesturday to show on chart
             keys = [Int](repeating:0, count:256)
+            
+            //  Clears our minutes, leaving the last 20 minutes, and than deletes the rest after 20 minutes
+            minutes.replaceSubrange(0..<1420, with: repeatElement(0, count: 1420))
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1200), execute: {
+                self.minutes.replaceSubrange(1420..<1440, with: repeatElement(0, count: 20))
+            })
         }
         
         keycount += 1
         
         let hour = calendar.component(.hour, from: date)
-        
-        if (0 < hour && hour < 23) {
-            minutes.replaceSubrange(1420..<1440, with: repeatElement(0, count: 20)) // Deletes the last 20 minutes of the previous day
-        }
-        
         let minute = calendar.component(.minute, from: date)
         minutes[hour*60 + minute] += 1
 

--- a/mac/keyrace-mac/keyrace_macApp.swift
+++ b/mac/keyrace-mac/keyrace_macApp.swift
@@ -102,13 +102,18 @@ class KeyTap {
         if (lastDay != day) {
             lastDay = day
             keycount = 0
-            minutes = [Int](repeating:0, count:1440)
+            minutes.replaceSubrange(0..<1420, with: repeatElement(0, count: 1420)) // Leave last 20 minutes of yesturday to show on chart
             keys = [Int](repeating:0, count:256)
         }
         
         keycount += 1
         
         let hour = calendar.component(.hour, from: date)
+        
+        if (0 < hour && hour < 23) {
+            minutes.replaceSubrange(1420..<1440, with: repeatElement(0, count: 20)) // Deletes the last 20 minutes of the previous day
+        }
+        
         let minute = calendar.component(.minute, from: date)
         minutes[hour*60 + minute] += 1
 
@@ -134,7 +139,12 @@ class KeyTap {
         let hour = calendar.component(.hour, from: date)
         let min = calendar.component(.minute, from: date)
         let currMin = hour*60 + min
-        return Array(minutes[currMin - 20...currMin])
+        
+        var mins : [Int] = []
+        for i in (0...20).reversed() {
+            currMin - i > 0 ? mins.append(minutes[currMin - i]): mins.append(minutes[1440 - i])
+        }
+        return mins
     }
 
     func getHoursChart() -> [Int] {


### PR DESCRIPTION
Fixed an issue where timechart did not properly roll over between days, and crashed the program (and slowed down the users computer significantly) between 12:00 am and 12:19 am. Also fixed an issue where midnight was displayed as '0am'.