### PR TITLE
Add handling for incorrect credentials (revoked tokens)

### DIFF
--- a/mac/keyrace-mac/GitHub.swift
+++ b/mac/keyrace-mac/GitHub.swift
@@ -26,8 +26,12 @@ class GitHub {
         
         let filename = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(GitHub.TOKEN_FILE)
         self.token = try? String(contentsOf: filename, encoding: .utf8)
-        getUserName() // FIXME: save/load username in a file to avoid this
-        self.loggedIn = true
+        if token != nil {
+            getUserName() // FIXME: save/load username in a file to avoid this
+            self.loggedIn = true
+        } else {
+            return
+        }
     }
     
     private func saveToken() {
@@ -116,6 +120,16 @@ class GitHub {
                 if let login = json["login"] as? String {
                     username = login
                 }
+            }
+        } else if let response = response as? HTTPURLResponse, response.statusCode == 401 {
+            // Bad credentials, therefore user needs to re-authenticate, so we can remove the file.
+            let filename = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(GitHub.TOKEN_FILE)
+            
+            do {
+                self.token = ""
+                try FileManager.default.removeItem(at: filename)
+            } catch {
+                NSLog("Could not delete old token from \(filename)")
             }
         }
     }

--- a/mac/keyrace-mac/MenubarItem.swift
+++ b/mac/keyrace-mac/MenubarItem.swift
@@ -248,6 +248,20 @@ class MenubarItem : NSObject {
             loginMenuItem.title = "Logged in as @" + gh!.username!
             loginMenuItem.isEnabled = false
             loginMenuItem.target = nil
+        } else {
+            let alert = NSAlert()
+            alert.messageText = "We could not log in with existing credentials. Would you like to retry?"
+            alert.addButton(withTitle: "Yes")
+            alert.addButton(withTitle: "No")
+            let modalResult = alert.runModal()
+            
+            switch modalResult {
+            case .alertFirstButtonReturn:
+                // User wants to re-authenticate.
+                login()
+            default:
+                return
+            }
         }
     }
     
@@ -256,7 +270,7 @@ class MenubarItem : NSObject {
             return
         }
         
-        if gh!.token != nil {
+        if !(gh!.token ?? "").isEmpty {
             gh!.getUserName()
             loggedIn()
             return


### PR DESCRIPTION
There is a potential scenario where the token is revoked, after which it will be impossible to log in to GitHub unless you remove the token file. This pull requests makes sure that the "cleanup" is done by the app itself, and the user has a chance to re-authenticate.