### PR TITLE
Fix crash for invalid (out of bounds) keycode

### DIFF
--- a/mac/keyrace-mac/KeyTap.swift
+++ b/mac/keyrace-mac/KeyTap.swift
@@ -106,7 +106,7 @@ class KeyTap {
 
         if keys.indices.contains(Int(keyCode)) {
             keys[Int(keyCode)] += 1
-        } else {
+        } else if keys.count > keyCode {
             keys[Int(keyCode)] = 0
         }
 


### PR DESCRIPTION
keyrace crashes if you hit certain key combos. Steps to repro:

1. Launch keyrace
2. Hit Shift-Option-Command v, for example
3. keyrace crashes

